### PR TITLE
Padding and plot limits, extremely small step sizes

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -1,3 +1,4 @@
 Thomas Lecocq
 Aurélien Mordret
 Dylan Mikesell
+John Paustian

--- a/msnoise_tomo/ANSWT.py
+++ b/msnoise_tomo/ANSWT.py
@@ -451,6 +451,8 @@ def ANSWT(gridfile,stacoordfile,DCfile,paramfile,PERIOD, show, v_cmap, d_cmap):
         m._A = []
         plt.colorbar(m)
         plt.contour(X+dx/2, Y+dy/2, Dsity, [1,], colors='k')
+        plt.xlim(lonlim[0], lonlim[1])
+        plt.ylim(latlim[0], latlim[1])
         plt.ylabel('Latitude')
         plt.xlabel('Longitude')
         plt.title("Period = %.3f s, Vmean= %.3f km/s" %

--- a/msnoise_tomo/prepare_tomo.py
+++ b/msnoise_tomo/prepare_tomo.py
@@ -75,10 +75,10 @@ def main():
             f = open(of,'w')
             xstep = float(get_config(db, "xstep", plugin="Tomo"))
             ystep = float(get_config(db, "ystep", plugin="Tomo"))
-            minlon = df[3].min() - xstep*2 - 0.005
-            maxlon = df[3].max() + xstep*2 + 0.005
-            minlat = df[2].min() - ystep*2 - 0.005
-            maxlat = df[2].max() + ystep*2 + 0.005
+            minlon = df[3].min() - xstep*2 - xstep
+            maxlon = df[3].max() + xstep*2 + xstep
+            minlat = df[2].min() - ystep*2 - ystep
+            maxlat = df[2].max() + ystep*2 + ystep
             f.write("%f %f\n"%(minlon, maxlon))
             f.write("%f %f\n"%(minlat, maxlat))
             f.write("%f %f\n"%(xstep, ystep))

--- a/msnoise_tomo/prepare_tomo.py
+++ b/msnoise_tomo/prepare_tomo.py
@@ -75,14 +75,14 @@ def main():
             f = open(of,'w')
             xstep = float(get_config(db, "xstep", plugin="Tomo"))
             ystep = float(get_config(db, "ystep", plugin="Tomo"))
-            minlon = df[3].min() - xstep*2 - xstep
-            maxlon = df[3].max() + xstep*2 + xstep
-            minlat = df[2].min() - ystep*2 - ystep
-            maxlat = df[2].max() + ystep*2 + ystep
+            minlon = df[3].min() - xstep*1.5 
+            maxlon = df[3].max() + xstep*1.5 
+            minlat = df[2].min() - ystep*1.5 
+            maxlat = df[2].max() + ystep*1.5 
             f.write("%f %f\n"%(minlon, maxlon))
             f.write("%f %f\n"%(minlat, maxlat))
             f.write("%f %f\n"%(xstep, ystep))
-            f.close()
+            f.close
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Fixes issue #10, replaces hard-coded padding with a percentage of step size. Adds limits to path plot to mimic density and group velocity plots. 

![02density](https://user-images.githubusercontent.com/51334141/87160691-98009980-c280-11ea-98f9-1269ae5aeec4.PNG)
![02groupv](https://user-images.githubusercontent.com/51334141/87160685-96cf6c80-c280-11ea-8fc4-e04501e1585c.PNG)
![02raypath](https://user-images.githubusercontent.com/51334141/87160678-946d1280-c280-11ea-85ab-bdab70d50c3e.PNG)

