### PR TITLE
Interactive Dispersion Curve Picking

### DIFF
--- a/Interactive_Dispersion_Curve_Picker_README.md
+++ b/Interactive_Dispersion_Curve_Picker_README.md
@@ -1,0 +1,126 @@
+# Interactive FTAN Ridge Picker
+ 
+This adds an interactive picking step on top of MSNoise Tomo's FTAN stage. It doesn't replace anything in the existing pipeline — it sits between the C++ FTAN computation and the file it normally writes (`write_disp.txt`), letting you see and correct what gets picked before it's handed off to `TOMO_DISP`.
+ 
+## The problem this solves
+ 
+If you've run the stock FTAN step on a real dataset, you've probably hit some combination of these:
+ 
+- The dispersion curve `vg_fta.so` hands back often isn't trustworthy. It jumps between unrelated peaks in the FTAN diagram and the resulting curve gets discontinuous in several places, with no way to see *why* it picked what it picked.
+- There was no real way to intervene — IFTAN exists, but driving it to fix a single bad pick is more confusing than it should be.
+- FTAN flags every job as done as soon as a batch starts. If a run gets interrupted or crashes partway through, the jobs already *look* finished to MSNoise, so you can't just resume — you have to manually sort out which pairs actually have a usable result.
+- After running FTAN repeatedly in the same session, the program eventually stops being able to load new contour plots at all.
+## What this adds
+ 
+- A peak-detection pass over the full group-velocity-vs-period (or frequency) SNR field for each pair, which finds every local maximum and stitches together the most continuous dispersion curve it can from them.
+- That algorithm-picked curve overrides whatever the raw FTAN binary would have used on its own, and instead of trusting it blindly, it's shown to you on a plot so you can accept or correct it.
+- Every candidate peak is plotted as a clickable point. You build your own curve by selecting points with the mouse; your selection is drawn in red, and the algorithm's own continuous guess is drawn in green underneath it for reference.
+- The picking parameters (described below) are exposed in a panel so you can tune them per pair, and your last-used values are cached to disk so you don't have to retype them for every single pair in a batch.
+- Undo/redo/clean controls so a bad rectangle-select or a stray misclick doesn't cost you the whole pair.
+- A `reset_ftan` command that lets you safely resume an interrupted batch, or — if you really need to — wipe everything and start clean.
+- A "Reboot" shortcut for the specific failure mode where FTAN stops being able to render new plots after running for a while: it terminates, resets the affected job(s), and restarts `msnoise p tomo ftan` for you.
+The final curve, once you save it, is rendered to a `.png` for your records and `write_disp.txt` is overwritten with your picks — from there, the existing MSNoise code relocates it into `TOMO_DISP/` exactly as before.
+ 
+## How the picking algorithm works
+ 
+For each period (or frequency) column in the FTAN amplitude diagram, the algorithm looks for local maxima in velocity, filtering out anything below a noise floor and merging maxima that are too close together to be meaningfully distinct. It then walks across columns, trying to connect one maximum per column into a single continuous ridge, rejecting connections that would require an implausibly large jump in velocity from one column to the next.
+ 
+The five parameters below control exactly how forgiving each of those steps is. Defaults are a reasonable starting point, but the right values genuinely depend on your data — frequency content, noise level, and station spacing all affect how clean the FTAN diagram looks. Expect to nudge them a little on your first few pairs. Once you land on values that work for your dataset, you won't have to re-enter them: the panel remembers your last-used values and reloads them automatically the next time the window opens.
+ 
+| Parameter | Label in the GUI | What it controls |
+|---|---|---|
+| `Xtol` | X Peak Isolation | Minimum separation, along the period/frequency axis, for two candidate peaks to count as distinct. Anything closer together is merged into one (the stronger peak wins). |
+| `Ytol` | Y Peak Isolation | The same idea, but along the velocity axis. |
+| `AMPmin` | Minimum SNR | Noise floor. Points in the FTAN diagram below this amplitude are never considered candidate peaks at all. |
+| `mtol` | Slope Tolerance | The steepest allowed jump in velocity between two consecutive picks. If connecting the next candidate would exceed this, the ridge breaks there instead of jumping to an unrelated peak. |
+| `bias` | Positive Slope Bias | When there's a tie between two nearby candidates for the next point on the ridge, this biases the choice toward the one with higher velocity — i.e. toward a positive slope, which is the more common shape for a real dispersion curve. |
+ 
+Both `Xtol` and `Ytol` are in the same units as whatever's on the plot's axes (so typically seconds and km/s, but this follows your diagram type).
+ 
+## Selecting points with the mouse
+ 
+Once you click **Pick**, every candidate peak appears as a point on the contour plot and you're in selection mode:
+ 
+| Action | Effect |
+|---|---|
+| Click a single point | Toggle that point's selection on/off |
+| Click-and-drag a box | Select everything inside the box, deselect everything outside it |
+| **Alt** + drag a box | Add the points inside the box to your current selection, without touching anything else |
+| **X** (hold) + drag a box | Deselect only the points inside the box |
+| **Alt** + **X** + drag a box | Toggle (flip) the selection of just the points inside the box |
+| Click an empty part of the canvas | Deselect everything |
+ 
+Your live selection is drawn in red; the algorithm's own reference curve stays green underneath it so you can always compare the two.
+ 
+## The Toolbar
+ 
+**Pick** — Runs the peak-detection algorithm with whatever parameter values are currently in the panel, and switches you into selection mode. Use it when:
+- You don't like the pre-selected (green) curve and want to build your own from the candidate points, or
+- You've just changed one of the five parameters and want to see how the set of candidate maxima changes before you commit to a selection.
+
+**Undo** — Steps back to your previous selection state. Use it to recover from a misclick, or to back out of a selection that turned out worse than the one you had before.
+ 
+**Redo** — Steps forward again. Paired with Undo, this lets you flip back and forth between two candidate ridges to compare them before deciding which one to keep.
+ 
+**Clean** — Deselects any points you've picked that aren't actually part of the connected ridge — stray clicks, accidental extra selections, that sort of thing. Under the hood it doesn't go scanning for which points are "stray"; it just reloads the cached state of the current ridge, since that's already sitting in memory.
+ 
+**Save** — Commits your current selection (or the original algorithm curve, if you never clicked Pick at all) as the final dispersion curve for this pair, writes it out, and closes the window so the pipeline can move on. If the default curve already looked fine to you, you can skip picking entirely and just hit Save.
+ 
+**Reboot** — For when FTAN has stopped being able to load new contour plots after running for a while in the same session: this terminates the current process, resets the affected job(s), and restarts `msnoise p tomo ftan` automatically so you don't have to do it by hand.
+ 
+### The matplotlib navigation toolbar
+ 
+**Zoom** — Enlarges a region of the plot. Useful when a stretch of the FTAN diagram has a dense cluster of candidate points and you need more room to click the right one.
+ 
+**Pan** — Shifts the view without changing the zoom level. Most of the time this is just for moving around a zoomed-in region, but it has one more niche use: points sitting right at the edge of the plot sometimes don't register clicks or fall inside a drag box properly. Panning the view so that point is no longer at the very edge usually fixes it.
+ 
+**Home** — Resets the view back to the original, full extent.
+ 
+### Closing the window
+ 
+Closing the window with the operating system's own **X / close button** is deliberately different from Save: instead of writing anything out, it safely terminates the process and resets the job for that pair, so MSNoise sees it as not-yet-done rather than wrongly marked complete. This means `msnoise p tomo ftan` will pick that pair back up cleanly the next time you run it — but it also means closing this way does **not** save whatever you'd selected. Use Save when you want to keep a pick; use the close button when you want to bail out of the current pair without keeping anything.
+ 
+## Dark mode
+ 
+The picker checks your OS's light/dark setting on startup and matches it automatically, falling back to light mode if it can't tell. You can flip it manually at any point with the dark-mode shortcut below — this recolors the plot, the panel, and the toolbar icons together.
+ 
+## Keyboard shortcuts
+ 
+| Key(s) | Action |
+|---|---|
+| Enter, Ctrl+P | Pick |
+| Ctrl+Z | Undo |
+| Ctrl+Y | Redo |
+| Ctrl+V, Alt+V | Clean |
+| Ctrl+S | Save |
+| Ctrl+R | Reboot |
+| Ctrl+D | Toggle dark mode |
+| o, Shift+Z | Toolbar: Zoom *(plot must have focus)* |
+| p, Shift+M | Toolbar: Pan *(plot must have focus)* |
+| h, Shift+H, Home | Toolbar: Home/reset view *(plot must have focus)* |
+| ← | Back to previous view *(plot must have focus)* |
+| → | Forward to next view *(plot must have focus)* |
+| \\, \|, r | Return focus to the plot canvas |
+ 
+The plot-navigation shortcuts only fire while the plot itself has focus — click on the plot once if they don't seem to respond.
+ 
+## Resuming or resetting a run
+ 
+```
+msnoise p tomo reset_ftan
+```
+Resets the job flags for the FTAN stage without deleting anything on disk. Combined with the fact that a pair already has a saved plot is treated as "done" and skipped automatically, this is the safe way to resume after an interruption — finished pairs stay finished, unfinished ones get picked back up.
+ 
+```
+msnoise p tomo reset_ftan --all
+```
+A full wipe: deletes every saved plot and resets every job. Since this throws away all picking progress and can't be undone, it asks you to type `DELETE PROGRESS` to confirm before doing anything.
+ 
+## Output files
+ 
+| File / folder | Contents |
+|---|---|
+| `DISP CURVE PLOTS/<filter>/<comp>/<STA1> - <STA2>.png` | The rendered review plot for the pair — also doubles as the marker that tells a future run this pair is already done |
+| `DISP CURVE PLOTS/params.pkl` | Your last-used picking parameters |
+| `write_disp.txt` | The final (Period, Velocity, Energy) picks for the current pair, picked up from there by the existing MSNoise code and relocated into `TOMO_DISP/` |
+ 

--- a/Interactive_Dispersion_Curve_Picker_README.md
+++ b/Interactive_Dispersion_Curve_Picker_README.md
@@ -20,6 +20,28 @@ If you've run the stock FTAN step on a real dataset, you've probably hit some co
 - A `reset_ftan` command that lets you safely resume an interrupted batch, or — if you really need to — wipe everything and start clean.
 - A "Reboot" shortcut for the specific failure mode where FTAN stops being able to render new plots after running for a while: it terminates, resets the affected job(s), and restarts `msnoise p tomo ftan` for you.
 The final curve, once you save it, is rendered to a `.png` for your records and `write_disp.txt` is overwritten with your picks — from there, the existing MSNoise code relocates it into `TOMO_DISP/` exactly as before.
+
+## Files changed and added
+
+### Modified
+
+| File | What changed |
+|---|---|
+| `plugin_definition.py` | Added the `reset_ftan` command to the `tomo` CLI group, including the `--all` flag and its `DELETE PROGRESS` confirmation gate. |
+| `ftan.py` | Before queuing a SAC file for processing, now checks whether its output plot already exists under `DISP CURVE PLOTS/`. If it does, that pair is skipped — this is what lets a resumed run skip pairs you've already picked instead of redoing the whole batch. |
+| `ftan_call.py` | After the FTAN binary's second (refined) pass, builds the picker's data object from its output and hands control to the picker window. If you used the picker, reloads `write_disp.txt` afterward so your edited picks — rather than the binary's raw output — are what get carried forward. |
+
+### Added
+
+| File | What it does |
+|---|---|
+| `Caller.py` | Launches the picker window, blocks until you close it, then pulls out whatever ridge you ended up with and writes it to `write_disp.txt`. |
+| `Interface.py` | The picker GUI itself — the plot panel, the parameter panel with the five tunable values, dark mode, and the Pick/Undo/Redo/Clean/Save/Reboot buttons. |
+| `Map.py` | The peak-detection scan — for each period/frequency column, finds local maxima in the SNR field using the `Xtol`/`Ytol`/`AMPmin` tolerances. |
+| `Point.py` | Represents each candidate peak (its position and selected/deselected state), the ridge-stitching logic (`mtol`/`bias`), and `Interact`, which owns the shared scatter plot and handles all the click/drag/alt/x mouse interactions. |
+| `cache.py` | The small history stack behind Undo, Redo, and Clean. |
+| `idisp_pick.py` | Bridges the raw FTAN output (amplitude matrix, axes, the binary's own picked curve) to the picker GUI — builds both the initial review plot and the interactive picking plot. |
+| `reset_ftan.py` | Implements both `reset_ftan` modes: the flag-only reset, and the destructive `--all` wipe that also deletes saved plots. |
  
 ## How the picking algorithm works
  

--- a/msnoise_tomo/Caller.py
+++ b/msnoise_tomo/Caller.py
@@ -1,0 +1,53 @@
+"""
+Launches the FTAN ridge-picking GUI from the MSNoise Tomo pipeline.
+
+Blocks on app.mainloop() until the user closes the picker window, then
+keeps running with whatever the picker handed back.
+"""
+
+import numpy as np
+import tkinter as tk
+from .Interface import App
+from .Point import Point
+
+
+def main(data):
+
+    captured = {}
+
+    def on_close(result):
+
+        print("App Closed!!")
+
+        captured["result"] = result
+
+        if data["idisp"].picked:
+            pts = result["picker"]
+            icol = {}
+            for P in pts.selected:
+                if P.x in icol:
+                    icol[P.x].append(P)
+                else:
+                    icol[P.x] = [P]
+
+            pts = Point.ridge(icol, list(sorted(icol.keys())), Point(0, 2))
+            M = data["idisp"].M
+            D = np.array([[*i(), M[i]] for i in pts])
+            np.savetxt('write_disp.txt', D, header='Period(s) Velocity(km/s) Energy')
+
+    existing_root = tk._default_root
+    created_root = existing_root is None
+    root = tk.Tk() if created_root else existing_root
+    if created_root:
+        root.withdraw()  # standalone case: hide the throwaway helper root, only the picker is visible
+
+    app = App(master=root, data=data, on_close=on_close)
+    app.wait_window()  # blocks only until THIS window closes, regardless of any other open windows
+
+    if created_root:
+        root.destroy()  # clean up only the helper root we made; never touches a pre-existing one
+
+    print("Result captured from the picker:", captured.get("result"))
+
+    # ... continue your pipeline: save picks to DB, move to next
+    # station pair, etc.

--- a/msnoise_tomo/Interface.py
+++ b/msnoise_tomo/Interface.py
@@ -159,7 +159,7 @@ class ParameterPanel(ttk.Frame):
             ("Ytol", "Y Peak Isolation", saved.get("Ytol", 0.01), (0, None)),
             ("mtol", "Slope Tolerance", saved.get("mtol", 1),  (0, None)),
             ("AMPmin", "Minimum SNR", saved.get("AMPmin", 0.25), (0, 1)),
-            ("bias", "Positive Slope Bias", saved.get("Bias", 2),  (0, None)),
+            ("bias", "Positive Slope Bias", saved.get("bias", 2),  (0, None)),
         ]
 
         btn = [

--- a/msnoise_tomo/Interface.py
+++ b/msnoise_tomo/Interface.py
@@ -1,0 +1,684 @@
+"""
+Interactive FTAN Ridge-Picking GUI
+-----------------------------------
+A Tkinter shell with a matplotlib plot on top and a parameter panel +
+"Pick" button on the bottom. Clicking "Pick" reads validated parameters,
+discards whatever plot is currently shown, and renders a fresh
+(interactive) plot built from those parameters.
+
+Designed to be launched FROM another program: pass data in via the
+constructor, get a result out via an on_close callback (or by reading
+app.result after mainloop() returns).
+
+Replace the two marked functions with your actual plotting code:
+    - build_default_plot()      -> the static plot shown on startup
+    - build_interactive_plot()  -> your ridge-picking interactive plot
+"""
+
+import tkinter as tk
+from tkinter import ttk
+import pickle
+import matplotlib
+from matplotlib.backend_bases import key_press_handler, KeyEvent
+
+matplotlib.use("TkAgg")
+from .cache import Cache
+import numpy as np
+import matplotlib.pyplot as plt
+from matplotlib.figure import Figure
+from matplotlib.backends.backend_tkagg import FigureCanvasTkAgg, NavigationToolbar2Tk
+import os
+import shutil
+from pathlib import Path
+
+PARAMS_cache = "DISP CURVE PLOTS/params.pkl"
+ICON_CACHE_DIR = os.path.join(Path(__file__).resolve().parent,"img")
+
+
+# ---------------------------------------------------------------------
+# Dark-mode color palettes. Only used when dark mode is actually ON.
+# When dark mode is OFF, ttk widgets simply revert to whatever native
+# theme the platform was already using, and the matplotlib figures
+# fall back to the "light" entries below (standard white/black look).
+# ---------------------------------------------------------------------
+THEMES = {
+    "dark": {
+        "bg": "#2b2b2b",
+        "fg": "#e0e0e0",
+        "button_bg": "#3c3f41",
+        "button_active": "#4b4f52",
+        "entry_bg": "#3c3f41",
+        "entry_fg": "#e0e0e0",
+        "text_bg": "#2b2b2b",
+        "text_fg": "#e0e0e0",
+        "error_fg": "#ff6b6b",
+        "fig_bg": "#2b2b2b",
+        "ax_bg": "#2b2b2b",
+        "ax_fg": "#e0e0e0",
+    },
+    "light": {
+        # Only fig_bg/ax_bg/ax_fg are used (to recolor matplotlib
+        # figures back to a standard look). ttk widgets revert to the
+        # platform's native theme rather than using this dict.
+        "fig_bg": "#ffffff",
+        "ax_bg": "#ffffff",
+        "ax_fg": "#000000",
+    },
+}
+
+
+def _detect_system_dark_mode():
+    """Best-effort check of the OS-level dark/light setting.
+    Returns False (light) if it can't be determined."""
+    import sys
+    try:
+        if sys.platform == "win32":
+            import winreg
+            key = winreg.OpenKey(
+                winreg.HKEY_CURRENT_USER,
+                r"Software\Microsoft\Windows\CurrentVersion\Themes\Personalize",
+            )
+            value, _ = winreg.QueryValueEx(key, "AppsUseLightTheme")
+            return value == 0  # 0 = dark, 1 = light
+        elif sys.platform == "darwin":
+            import subprocess
+            result = subprocess.run(
+                ["defaults", "read", "-g", "AppleInterfaceStyle"],
+                capture_output=True, text=True,
+            )
+            return result.stdout.strip() == "Dark"
+        else:  # Linux/other desktops (GNOME-based)
+            import subprocess
+            result = subprocess.run(
+                ["gsettings", "get", "org.gnome.desktop.interface", "color-scheme"],
+                capture_output=True, text=True,
+            )
+            return "dark" in result.stdout.lower()
+    except Exception:
+        return False
+
+def _invert_named_image(tk_interp, name):
+    w = int(tk_interp.call('image', 'width', name))
+    h = int(tk_interp.call('image', 'height', name))
+
+    def _rgb(x, y):
+        val = tk_interp.call(name, 'get', x, y)
+        if isinstance(val, str):
+            return tuple(map(int, val.split()))
+        return tuple(int(v) for v in val)
+
+    rows = []
+    for y in range(h):
+        row = " ".join("#%02x%02x%02x" % (255 - r, 255 - g, 255 - b)
+                        for r, g, b in (_rgb(x, y) for x in range(w)))
+        rows.append("{" + row + "}")
+
+    inverted = tk.PhotoImage(width=w, height=h)
+    inverted.put(" ".join(rows))
+    for y in range(h):
+        for x in range(w):
+            if tk_interp.call(name, 'transparency', 'get', x, y):
+                inverted.transparency_set(x, y, True)
+    return inverted
+
+
+class ParameterPanel(ttk.Frame):
+    """Bottom panel: 4 validated float parameters + Pick button."""
+
+    @staticmethod
+    def _load_saved_defaults():
+        try:
+            with open(PARAMS_cache, "rb") as f:
+                return pickle.load(f)
+        except (FileNotFoundError, EOFError, pickle.UnpicklingError, OSError):
+            return {}  # no cache yet, or it's corrupted -> fall back to hardcoded defaults
+
+    @staticmethod
+    def _save_defaults(params):
+        try:
+            with open(PARAMS_cache, "wb") as f:
+                pickle.dump(params, f)
+        except OSError:
+            pass  # non-fatal: worst case, next run just uses the hardcoded defaults
+
+    def __init__(self, master, on_pick,on_undo,on_redo,on_clean,on_save,on_toggle_theme=None):
+        super().__init__(master, padding=(10, 8))
+        self.on_pick = on_pick
+        self.on_undo = on_undo
+        self.on_redo = on_redo
+        self.on_clean = on_clean
+        self.on_save = on_save
+        self.on_toggle_theme = on_toggle_theme
+
+        # (key, label, default, (lo, hi))  -- hi/lo = None means unbounded
+
+
+        saved = self._load_saved_defaults()
+        self.specs = [
+            ("Xtol", "X Peak Isolation", saved.get("Xtol", 0.1), (0, None)),
+            ("Ytol", "Y Peak Isolation", saved.get("Ytol", 0.01), (0, None)),
+            ("mtol", "Slope Tolerance", saved.get("mtol", 1),  (0, None)),
+            ("AMPmin", "Minimum SNR", saved.get("AMPmin", 0.25), (0, 1)),
+            ("bias", "Positive Slope Bias", saved.get("Bias", 2),  (0, None)),
+        ]
+
+        btn = [
+            ("Pick", self._handle_pick, ["<Return>", "<Control-p>", "<Control-P>"], "[enter]/[Ctrl+P]"),
+            ("Undo", self._handle_undo, ["<Control-z>", "<Control-Z>"], "[Ctrl+Z]"),
+            ("Redo", self._handle_redo, ["<Control-y>", "<Control-Y>"], "[Ctrl+Y]"),
+            ("Clean", self._handle_clean, ["<Control-v>", "<Control-V>", "<Alt-v>", "<Alt-V>"], "[Ctrl+V]/[Alt+V]"),
+            ("Save", self.on_save, ["<Control-s>", "<Control-S>"], "[Ctrl+S]"),
+            ("Reboot", self._handle_reboot, ["<Control-r>", "<Control-R>"], "[Ctrl+R]")
+        ]
+
+
+        style = ttk.Style()
+        # Fallback to a standard light gray if the theme color cannot be read
+        bg_color = style.lookup("TFrame", "background") or "#f0f0f0"
+
+        self.log_text = tk.Text(
+            self,
+            height=5,
+            width=65,
+            wrap="word",
+            bg=bg_color,
+            font=("Sans", 10),
+            bd=0,
+            highlightthickness=0,
+        )
+
+        # Remember the original colors so dark mode can be turned back off
+        # and the log box returns to exactly how it looked before.
+        self._orig_log_bg = self.log_text.cget("bg")
+        self._orig_log_fg = self.log_text.cget("fg")
+
+        self.log_text.grid(
+            row=0, column=0, rowspan=2, padx=(30, 0), pady=5, sticky="w"
+        )
+
+        self._update_text(0)
+        self.columnconfigure(0, weight=0)
+
+        self.vars = {}
+        for col, (key, label, default, bounds) in enumerate(self.specs,1):
+            frame = ttk.Frame(self)
+            frame.grid(row=0, column=col, padx=8)
+
+            ttk.Label(frame, text=label).pack(anchor="s")
+
+            var = tk.StringVar(value=str(default))
+            entry = ttk.Entry(frame, textvariable=var, width=10)
+            entry.pack(anchor="n")
+            entry.delete(0, tk.END)
+            entry.insert(0, str(default))
+
+            self.vars[key] = var
+
+
+        for col, (text, func, bindings, label) in enumerate(btn, len(self.specs)+1):
+
+            button = ttk.Button(self, text=text, command=func)
+            button.grid(row=0, column=col, padx=(20, 20))
+
+            for key in bindings:
+                master.bind_all(key, func)
+
+            lbl = ttk.Label(self, text=label, font=("Sans", 9), foreground="gray")
+            lbl.grid(row=1, column=col, padx=(10, 10), sticky="n")
+
+        master.bind_all("<Control-d>",self._handle_toggle_theme)
+        master.bind_all("<Control-D>", self._handle_toggle_theme)
+
+
+        '''
+        pick_btn = ttk.Button(self, text="Pick", command=self._handle_pick)
+        pick_btn.grid(row=0, column=len(self.specs), padx=(20, 0))
+        master.bind_all("<Return>", self._handle_pick)
+        master.bind_all("<Control-p>", self._handle_pick)
+        master.bind_all("<Control-P>", self._handle_pick)
+        psl=ttk.Label(self, text="[enter]/[Ctrl+P]", font=("Sans", 10), foreground="gray")
+        psl.grid(row=1, column=len(self.specs), padx=(20, 0), sticky="n")
+        '''
+
+        ''''''
+        ncol = len(self.specs) + len(btn)
+        for col_idx in range(1,ncol+1):
+            self.columnconfigure(col_idx, weight=0)
+
+        ''''''
+
+        self.error_label = ttk.Label(self, text="", foreground="red")
+        self.error_label.grid(row=1, column=1, columnspan=len(self.specs), pady=(6, 0))
+
+    def _update_text(self, i):
+        instructions = [
+            """Hit Save to proceed with the prepicked dispersion curve.
+
+Click 'Pick' or press ENTER to pick dispersion curve.
+
+Press [Ctrl+D] to toggle appearance theme.
+""",
+            """Click on the points to select or deselect them.
+Drag over the points to select new points.
+Alt + Drag to add new points to the existing ridge.
+X + Drag to deselect points.
+Click any empty region of the canvas to discard all selections.
+        """
+        ]
+        self.log_text.config(state="normal")  # Unlock
+        self.log_text.delete("1.0", tk.END)  # Clear contents
+        self.log_text.insert(tk.END, instructions[i])  # Write text
+        self.log_text.config(state="disabled")
+
+    def _validate(self):
+        """Parse + range-check all fields. Returns dict, or None (+ shows error)."""
+        values = {}
+        for key, label, default, bounds in self.specs:
+            raw = self.vars[key].get().strip()
+            try:
+                val = float(raw)
+            except ValueError:
+                self.error_label.config(text=f"'{label}' must be a number.")
+                return None
+
+            lo, hi = bounds
+            if lo is not None and val < lo:
+                self.error_label.config(text=f"'{label}' must be >= {lo}.")
+                return None
+            if hi is not None and val > hi:
+                self.error_label.config(text=f"'{label}' must be <= {hi}.")
+                return None
+
+            values[key] = val
+
+        self.error_label.config(text="")
+        return values
+
+    def _handle_pick(self,event=None):
+        params = self._validate()
+        if params is not None:
+            self._save_defaults(params)
+            self.on_pick(params)
+            self._update_text(1)
+
+    def _handle_undo(self,event=None):
+        sucess=self.on_undo()
+        self.error_label.config(text="" if sucess else "Nothing to Undo.")
+
+    def _handle_redo(self,event=None):
+        sucess=self.on_redo()
+        self.error_label.config(text="" if sucess else "Nothing to Redo.")
+
+    def _handle_clean(self,event=None):
+        sucess=self.on_clean()
+        self.error_label.config(text="" if sucess else "Not in data picking mode. Click 'Pick' or press ENTER to pick dispersion curve.")
+
+    def _handle_reboot(self,event=None):
+        bash_path = shutil.which("bash") or "/bin/bash"
+        command_string = "msnoise p tomo reset_ftan && msnoise p tomo ftan"
+        exec_args = [bash_path, "-i", "-c", command_string]
+        os.execv(bash_path, exec_args)
+
+    def _handle_toggle_theme(self,event=None):
+        if self.on_toggle_theme is not None:
+            self.on_toggle_theme()
+
+    def apply_theme(self, theme):
+        """theme=None reverts this panel's plain-tk widgets to their
+        original colors (used when dark mode is switched off)."""
+        if theme is None:
+            self.log_text.configure(
+                bg=self._orig_log_bg, fg=self._orig_log_fg,
+                insertbackground=self._orig_log_fg,
+            )
+            self.error_label.configure(foreground="red")
+        else:
+            self.log_text.configure(
+                bg=theme["text_bg"], fg=theme["text_fg"],
+                insertbackground=theme["fg"],
+            )
+            self.error_label.configure(foreground=theme["error_fg"])
+
+
+class PlotPanel(ttk.Frame):
+    """Top panel: hosts whatever Figure is currently active."""
+
+    def __init__(self, master):
+        super().__init__(master)
+        self.canvas = None
+        self.toolbar = None
+        self.figure = None
+        # Strong reference to any interactive helper object (e.g. your
+        # Ridges/Point picker) so it isn't garbage-collected while shown.
+        self.active_picker = None
+        # Current color theme applied to any Figure shown here.
+        self.theme = THEMES["light"]
+        self._toolbar_orig_colors = {} #
+        self._toolbar_orig_images = {}
+        self._toolbar_dark_images = {}
+
+    def show_figure(self, fig, picker=None):
+        """Tear down whatever is currently displayed and embed a new Figure."""
+        if self.canvas is not None:
+            self.canvas.get_tk_widget().destroy()
+        if self.toolbar is not None:
+            self.toolbar.destroy()
+        if self.figure is not None:
+            plt.close(self.figure)
+
+        self.figure = fig
+        self.active_picker = picker  # keep alive for the lifetime of this plot
+
+        self.canvas = FigureCanvasTkAgg(fig, master=self)
+        self.canvas.draw()
+        widget = self.canvas.get_tk_widget()
+        widget.pack(side="top", fill="both", expand=True)
+
+        self.toolbar = NavigationToolbar2Tk(self.canvas, self, pack_toolbar=False)
+        self.toolbar.update()
+        self.toolbar.pack(side="bottom", fill="x")
+
+        shortcuts={
+            self.toolbar.zoom:["<o>","<O>","<Shift-z>","<Shift-Z>"],
+            self.toolbar.pan:["<p>","<P>","<Shift-m>","<Shift-M>"],
+            self.toolbar.home:["<h>","<H>","<Shift-h>","<Shift-H>","<Home>"],
+            self.toolbar.back:["<Left>"],
+            self.toolbar.forward:["<Right>"],
+            widget.focus_set:["<backslash>","<bar>","<r>","<R>"]
+        }
+
+        for func,keys in shortcuts.items():
+            for key in keys:
+                widget.bind(key,lambda e,f=func:f())
+
+        # Re-apply whatever theme is currently active so newly-built
+        # plots (e.g. after clicking "Pick") match the current mode.
+        self._toolbar_orig_colors = {}
+        self._style_toolbar()
+
+        self._recolor_current_figure()
+
+    def apply_theme(self, theme):
+        self.theme = theme if theme is not None else THEMES["light"]
+        self._recolor_current_figure()
+        self._style_toolbar()  #
+
+    def _recolor_current_figure(self):
+        if self.figure is None:
+            return
+        fig_bg = self.theme["fig_bg"]
+        ax_bg = self.theme["ax_bg"]
+        fg = self.theme["ax_fg"]
+
+        self.figure.patch.set_facecolor(fig_bg)
+        for ax in self.figure.get_axes():
+            ax.set_facecolor(ax_bg)
+            ax.tick_params(colors=fg, which="both")
+            ax.xaxis.label.set_color(fg)
+            ax.yaxis.label.set_color(fg)
+            ax.title.set_color(fg)
+            for spine in ax.spines.values():
+                spine.set_color(fg)
+            legend = ax.get_legend()
+            if legend is not None:
+                legend.get_frame().set_facecolor(fig_bg)
+                for text in legend.get_texts():
+                    text.set_color(fg)
+
+        if self.canvas is not None:
+            self.canvas.draw_idle()
+
+    def _style_toolbar(self):
+        if self.toolbar is None:
+            return
+        dark = self.theme is THEMES["dark"]
+        bg = self.theme.get("button_bg") if dark else None
+        fg = self.theme.get("fg") if dark else None
+
+        style = ttk.Style()
+        default_frame_bg = style.lookup("TFrame", "background") or "#f0f0f0"
+        default_label_fg = style.lookup("TLabel", "foreground") or "black"
+
+        for w in [self.toolbar] + list(self.toolbar.winfo_children()):
+            widget_type = w.winfo_class()
+            is_ttk = widget_type.startswith("T")
+            if w not in self._toolbar_orig_colors:
+                try:
+                    self._toolbar_orig_colors[w] = (w.cget("bg"), w.cget("fg"))
+                except tk.TclError:
+                    fallback_bg = (
+                        default_frame_bg
+                        if "Frame" in widget_type
+                        else "#f0f0f0"
+                    )
+                    fallback_fg = default_label_fg
+                    self._toolbar_orig_colors[w] = (fallback_bg, fallback_fg)
+
+            orig_bg, orig_fg = self._toolbar_orig_colors[w]
+
+            target_bg = bg if dark else orig_bg
+            try:
+                if is_ttk:
+                    # Clear explicit overrides for clean light mode fallback
+                    if not dark:
+                        w.configure(background="")
+                    else:
+                        w.configure(background=target_bg)
+                else:
+                    w.configure(bg=target_bg)
+            except tk.TclError:
+                try:
+                    w.configure(background=target_bg)
+                except tk.TclError:
+                    pass
+
+            target_fg = fg if dark else orig_fg
+            if target_fg is not None:
+                try:
+                    if is_ttk:
+                        if not dark:
+                            w.configure(foreground="")
+                        else:
+                            w.configure(foreground=target_fg)
+                    else:
+                        w.configure(fg=target_fg)
+                except tk.TclError:
+                    try:
+                        w.configure(foreground=target_fg)
+                    except tk.TclError:
+                        pass
+            
+            image_name = None
+            try:
+                image_name = w.cget("image")
+            except tk.TclError:
+                pass
+            if image_name:
+                if w not in self._toolbar_orig_images:
+                    self._toolbar_orig_images[w] = image_name  # just the string
+                orig_name = self._toolbar_orig_images[w]
+                if dark:
+                    if w not in self._toolbar_dark_images:
+                        self._toolbar_dark_images[w] = self._get_or_make_dark_icon(w, orig_name)
+                    w.configure(image=self._toolbar_dark_images[w])
+                else:
+                    w.configure(image=orig_name)
+
+    def _get_or_make_dark_icon(self, widget, image_name):
+        w = int(widget.tk.call('image', 'width', image_name))
+        h = int(widget.tk.call('image', 'height', image_name))
+        stable = os.path.basename(str(getattr(widget, "_image_file", None) or image_name))
+        key = f"{os.path.splitext(stable)[0]}_{w}x{h}"
+        path = os.path.join(ICON_CACHE_DIR, key + ".png")
+
+        if os.path.exists(path):
+            try:
+                return tk.PhotoImage(file=path)
+            except tk.TclError:
+                pass
+
+        inverted = _invert_named_image(widget.tk, image_name)
+        try:
+            os.makedirs(ICON_CACHE_DIR, exist_ok=True)
+            inverted.write(path, format="png")
+        except (OSError, tk.TclError):
+            pass
+        return inverted
+
+
+# ---------------------------------------------------------------------
+# Plug your real plotting logic in here. Both now accept `data` -- whatever
+# you passed into App(data=...) from the calling program.
+# ---------------------------------------------------------------------
+
+def build_default_plot(data=None):
+    """Static plot shown on startup. Replace with your initial station-pair view."""
+
+    fig=data["idisp"].main(data["filename"],data["dist"],data["comp"])
+
+    return fig, None
+
+
+def build_interactive_plot(params, data=None):
+    """
+    Build the interactive ridge-picking plot from validated parameters.
+
+    params keys: y_tol, slope_tol, min_snr, pos_slope_bias
+    data: whatever was passed into App(data=...)
+
+    Must return (fig, picker):
+        fig    - the matplotlib Figure to display
+        picker - any stateful object holding your interactive callbacks
+                 (e.g. a Ridges/Point picker instance), kept alive by
+                 PlotPanel. Pass None if you don't need one.
+    """
+    '''
+    fig = Figure(figsize=(8, 4.5), dpi=100)
+    ax = fig.add_subplot(111)
+    '''
+
+    fig,picker=data["idisp"].pick(params["Xtol"],params["Ytol"],params["mtol"],params["AMPmin"],params["bias"],data["idisp"].name,data["idisp"].per,data["idisp"].disper)
+    data["idisp"].picked = True
+
+    return fig, picker
+
+
+# ---------------------------------------------------------------------
+
+
+class App(tk.Toplevel):
+    def __init__(self, master=None, data=None, on_close=None):
+        super().__init__(master)
+        self.data = data
+        self.on_close_callback = on_close
+        self.result = False
+
+        # Dark-mode bookkeeping. Nothing visually changes yet -- the app
+        # still starts up looking exactly as it always did, in whatever
+        # native ttk theme the platform was already using.
+        self.dark_mode = _detect_system_dark_mode()
+        self._style = ttk.Style()
+        self._original_theme = self._style.theme_use()
+        self._original_bg = self.cget("bg")
+
+        self.title("FTAN Ridge Picker")
+        self.geometry("1920x1080")
+
+        self.plot_panel = PlotPanel(self)
+        self.plot_panel.pack(side="top", fill="both", expand=True)
+
+        self.param_panel = ParameterPanel(self, on_pick=self._on_pick,on_undo=self._on_undo,on_redo=self._on_redo,on_clean=self._on_clean,on_save=self._handle_close,on_toggle_theme=self._toggle_theme)
+        self.param_panel.pack(side="bottom", fill="x")
+
+        fig, picker = build_default_plot(self.data)
+        self.plot_panel.show_figure(fig, picker)
+
+        if self.dark_mode:
+            self._apply_theme(True)
+
+        # Intercept the window manager's close ("X") button. Without this,
+        # clicking X just destroys the window with no chance to run anything.
+        self.protocol("WM_DELETE_WINDOW", self._kill)
+
+    def _on_pick(self, params):
+        fig, picker = build_interactive_plot(params, self.data)
+        self.plot_panel.show_figure(fig, picker)
+        # Keep the latest params/picker as the running "result" so that
+        # whenever the window eventually closes, the most recent pick
+        # is what gets handed back.
+        self.result = {"params": params, "picker": picker}
+
+    def _on_undo(self):
+        R=Cache.undo()
+        if R:
+            self.result["picker"].force(R)
+            return True
+        return False
+
+    def _on_redo(self):
+        R=Cache.redo()
+        if R:
+            self.result["picker"].force(R)
+            return True
+        return False
+
+    def _on_clean(self):
+        R=Cache.current
+        if R and self.result:
+            self.result["picker"].force(R)
+            return True
+        return False
+
+    def _apply_theme(self, dark):
+        """Switch all panels between dark mode and the platform's native
+        look. Purely cosmetic -- no app state or behavior is touched."""
+        style = self._style
+
+        if dark:
+            if style.theme_use() != "clam":
+                # 'clam' is the only built-in ttk theme that reliably lets
+                # us recolor button/entry backgrounds across platforms.
+                style.theme_use("clam")
+            theme = THEMES["dark"]
+            style.configure("TFrame", background=theme["bg"])
+            style.configure("TLabel", background=theme["bg"], foreground=theme["fg"])
+            style.configure("TButton", background=theme["button_bg"], foreground=theme["fg"])
+            style.map("TButton", background=[("active", theme["button_active"])])
+            style.configure("TEntry", fieldbackground=theme["entry_bg"], foreground=theme["entry_fg"])
+            self.configure(bg=theme["bg"])
+        else:
+            # Switching back to the original theme restores that theme's
+            # own (untouched) style definitions automatically.
+            style.theme_use(self._original_theme)
+            theme = None
+            self.configure(bg=self._original_bg)
+
+        self.param_panel.apply_theme(theme)
+        self.plot_panel.apply_theme(theme)
+
+    def _toggle_theme(self, event=None):
+        self.dark_mode = not self.dark_mode
+        self._apply_theme(self.dark_mode)
+
+    def _kill(self,event=None):
+        bash_path = shutil.which("bash") or "/bin/bash"
+        command_string = "msnoise p tomo reset_ftan"
+        exec_args = [bash_path, "-i", "-c", command_string]
+        os.execv(bash_path, exec_args)
+
+    def _handle_close(self,event=None):
+        try:
+            if self.on_close_callback is not None:
+                self.on_close_callback(self.result)
+        except Exception:
+            import traceback
+            traceback.print_exc()
+        finally:
+            self.destroy()  # <-- always runs now, even if on_close blew up  # <-- this is what makes mainloop() return
+
+
+if __name__ == "__main__":
+    # Standalone test run: no external data, just print on close.
+    app = App(data=None, on_close=lambda result: print("Closed with result:", result))
+    app.mainloop()
+    print("App object still alive after mainloop() returned; result =", app.result)

--- a/msnoise_tomo/Map.py
+++ b/msnoise_tomo/Map.py
@@ -1,0 +1,212 @@
+import numpy as np
+from matplotlib.cm import inferno
+from .Point import *
+
+
+
+class Map:
+    def __init__(self, map, x, y,name=None):
+        self.map = map
+        self.x = x
+        self.y = y
+        self.name = name
+
+    def __repr__(self):
+        return f"""
+        Map Size: {len(self.x)}x{len(self.y)}
+        X-Range: {self.x[0]} - {self.x[-1]}
+        Y-Range: {self.y[0]} - {self.y[-1]}
+        """
+
+    def __getitem__(self, k):
+        if isinstance(k, Point): return self.map[search(self.x, k.x)][search(self.y, k.y)]
+
+        if isinstance(k, slice):
+            if np.ndim(self.map) != 1:
+                if k.step:
+                    result = []
+                    for i in np.arange(k.start, k.stop, k.step):
+                        result.append(self.map[search(self.x, i)])
+                    return Map(np.array(result), np.arange(k.start, k.stop, k.step), self.y)
+                else:
+                    i = search(self.x, k.start)
+                    f = search(self.x, k.stop) + 1
+                    return Map(self.map[i:f], self.x[i:f], self.y)
+            else:
+                if k.step:
+                    result = []
+                    for i in np.arange(k.start, k.stop, k.step):
+                        result.append(self.map[search(self.x, i)])
+                    return np.array(result)
+                else:
+                    i = search(self.y, k.start)
+                    f = search(self.y, k.stop) + 1
+                    return Map(self.map[i:f], self.x, self.y[i:f])
+
+        if np.ndim(self.map) != 1:
+            return Map(self.map[search(self.x, k)], np.array([k]), self.y)
+        else:
+            return self.map[search(self.y, k)]
+
+    def setTol(self,Xtol,Ytol,mtol,AMPmin,bias):
+        self.Xtol = Xtol
+        self.Ytol = Ytol
+        self.mtol = mtol
+        self.AMPmin = AMPmin
+        self.bias = bias
+
+    def __iter__(self):
+        for i in self.map: yield i
+
+    def maxima(self, x,Xtol=0, Ytol=0,AMPmin=0):
+        if Xtol ==0: Xtol=self.Xtol
+
+        if Ytol == 0:
+            Ytol = self.Ytol
+
+        if AMPmin == 0:
+            AMPmin = self.AMPmin
+
+        '''
+        ''''''
+        x_spacing = self.x[1] - self.x[0] if len(self.x) > 1 else 1
+        idx_tol = max(1, int(Xtol / x_spacing))
+        idx=search(self.x, x)
+        start_bound = max(0, idx - idx_tol)
+        end_bound = min(len(self.x), idx + idx_tol + 1)
+        ampx=self.map[start_bound:end_bound].T
+        ''''''
+
+        amp_obj = self[x]
+        amp_data = amp_obj.map
+
+        y_spacing = self.y[1] - self.y[0] if len(self.y) > 1 else 1
+        idy_tol = max(1, int(Ytol / y_spacing))
+
+        peaks = set()
+        trail=False
+        for idy in range(len(self.y)):
+            if amp_data[idy] > AMPmin:
+                start_bound = max(0, idy - idy_tol)
+                end_bound = min(len(self.y), idy + idy_tol + 1)
+                if amp_data[idy] == max(amp_data[start_bound:end_bound]): #
+                    peaks.add(self.y[idy])
+                    ''''''
+                    trail=True
+                elif amp_data[idy] == max(ampx[idy]):
+                    if trail:
+                        match = next((x for x in peaks if x in set(self.y[start_bound:end_bound])), None)
+                        if match:
+                            if amp_data[idy]>self[x][match]:
+                                peaks.remove(match)
+                                peaks.add(self.y[idy])
+                        else:
+                            peaks.add(self.y[idy])
+                    else:
+                        peaks.add(self.y[idy])
+                        trail=True
+                else: trail=False
+            else: trail=False
+            ''''''
+            '''
+
+        def is_ridge(mat):
+            c = mat[1][1]
+            ld = c > mat[0][0] and c > mat[2][2]
+            rd = c > mat[2][0] and c > mat[0][2]
+
+            return ld or rd
+
+        peaks=set()
+        A = self.map
+
+        idx = search(self.x, x)
+        sx = max(0, min(idx - 1,search(self.x, x-Xtol)))
+        ex = min(len(self.x), max(idx + 1,search(self.x, x+Xtol)))
+        ampx=A[sx:ex].T
+
+        amp_obj = self[x]
+        ampy = amp_obj.map
+
+        y_spacing = self.y[1] - self.y[0] if len(self.y) > 1 else 1
+        idy_tol = max(1, int(Ytol / y_spacing))
+
+        trail = False
+        for idy in range(len(self.y)):
+            if ampy[idy] > AMPmin:
+                sy = max(0, idy - idy_tol)
+                ey = min(len(self.y), idy + idy_tol + 1)
+
+                if (is_ridge([[A[sx][sy], 0, A[ex-1][sy]],
+                             [0, A[idx][idy], 0],
+                             [A[sx][ey-1], 0, A[ex-1][ey-1]]])
+                        or ampy[idy] == max(ampy[sy:ey]) or ampy[idy] == max(ampx[idy])):
+                    if trail:
+                        match = next((x for x in peaks if x in set(self.y[sy:ey])), None)
+                        if match:
+                            if ampy[idy] > self[x][match]:
+                                peaks.remove(match)
+                                peaks.add(self.y[idy])
+                        else:
+                            peaks.add(self.y[idy])
+                    else:
+                        peaks.add(self.y[idy])
+                        trail = True
+                else: trail = False
+            else: trail = False
+
+
+        return np.array(sorted(peaks))
+
+    def scan(self):
+        peaks={}
+        for x in self.x:
+            y = self.maxima(x)
+            P = [Point(x, i) for i in y]
+            #yield x, P
+            peaks[x] = P
+
+        for x,y in self.prepick.items():
+            if x in peaks:
+                if y not in [p.y for p in peaks[x]]: peaks[x].append(Point(x,y))
+            else: peaks[x] = [Point(x,y)]
+
+        for x,P in peaks.items():
+            yield x, P
+
+    def default(self,per,disper):
+        self.prepick = {}
+        for i,j in zip(per,disper):self.prepick[i] = j
+
+    def plot(self, ax=plt, show=True):
+
+        if isinstance(ax, MT):
+            fig = plt.Figure()
+            ax = fig.add_subplot(111)
+        else:
+            fig = ax.get_figure()
+
+        Per, Vitg = np.meshgrid(self.x, self.y)
+        heatmap = ax.contourf(Per, Vitg, self.map.T, 35, cmap=inferno)
+
+        ax.set_xlim(Per.min(), Per.max())
+        ax.set_ylim(Vitg.min(), Vitg.max())
+
+        col=[]
+        icol={}
+        for x,P in self.scan():
+            icol[x]=P
+            col+=P
+
+        Point.iridge(icol,self.x,Point(0,2.5),self.mtol,self.bias).plot(ax)
+        pts=Interact(col,ax)
+
+        fig.colorbar(heatmap, label="Signal Strength")
+        ax.set_xlabel("Time Period (s)")
+        ax.set_ylabel("Group Velocity (km/s)")
+        ax.set_title(self.name)
+
+        fig.tight_layout()
+
+        return fig,pts
+

--- a/msnoise_tomo/Point.py
+++ b/msnoise_tomo/Point.py
@@ -1,0 +1,540 @@
+from functools import total_ordering
+import matplotlib.pyplot as plt
+import numpy as np
+from matplotlib.widgets import RectangleSelector
+from types import ModuleType as MT
+from .cache import Cache
+
+def search(arr, n):
+    if len(arr)==0:
+        return -1
+    arr = np.asarray(arr)
+    idx = np.searchsorted(arr, n)
+    if idx == 0:
+        return 0
+    if idx == len(arr):
+        return len(arr) - 1
+    if abs(arr[idx] - n) < abs(arr[idx - 1] - n):
+        return idx
+    return idx - 1
+
+
+@total_ordering
+class Point:
+    """
+    Holds position + selection state only. Rendering and click-handling
+    now live entirely in Interact, which owns ONE shared scatter for all
+    points instead of one scatter (and one pick_event connection) per
+    Point. See Interact for _on_pick / _sync_colors.
+    """
+
+    def __init__(self, x, y):
+        self.__x = x
+        self.__y = y
+        self._deselect()
+
+    @property
+    def x(self):
+        return self.__x
+
+    @property
+    def y(self):
+        return self.__y
+
+    def __call__(self):
+        return self.x, self.y
+
+    def __repr__(self):
+        return f"({self.x}, {self.y})"
+
+    def slope(self, P):
+        if isinstance(P, Point):
+            try:
+                return (P.y - self.y) / (P.x - self.x)
+            except ZeroDivisionError:
+                return float('inf')
+        else:
+            raise TypeError(f"{type(P)} object {P} is incompatible to point {self}")
+
+    def __gt__(self, P):
+        if isinstance(P, Point):
+            return self.x > P.x
+        else:
+            raise TypeError(f"{type(P)} object {P} is incompatible to point {self}")
+
+    def __eq__(self, P):
+        if isinstance(P, Point):
+            return self.x == P.x and self.y == P.y
+        else:
+            raise TypeError(f"{type(P)} object {P} is incompatible to point {self}")
+
+    def _select(self):
+        self.__selected = True
+        self._col = "red"
+
+    def _deselect(self):
+        self.__selected = False
+        self._col = "green"
+
+    @property
+    def selected(self):
+        return self.__selected
+
+    @staticmethod
+    def ridge(icol, xs, iP):
+        pts = []
+        for x in sorted(icol.keys()):
+            if len(icol[x]) > 0:
+                Px = icol[x]
+                y = [i.y for i in Px]
+                id = search(y, iP.y)
+                if y[id] < iP.y and id < len(icol[x]) - 1:
+                    if y[id + 1] - iP.y < (iP.y - y[id]): id += 1
+                Px[id]._select()
+                iP = Px[id]
+                pts.append(iP)
+
+        return Ridge(pts)
+
+    @staticmethod
+    def iridge(icol, xs, iP, tol, bias):
+        pts = []
+        for x in xs:
+            if len(icol[x]) > 0:
+                Px = icol[x]
+                y = [i.y for i in Px]
+                id = search(y, iP.y)
+                ud = id
+                if y[id] < iP.y and id < len(icol[x]) - 1:
+                    if y[id + 1] - iP.y < bias * (iP.y - y[id]): ud += 1
+                new = True
+                if -tol <= iP.slope(Px[ud]) <= tol:
+                    iP = Px[ud]
+                elif -tol <= iP.slope(Px[id]) <= tol:
+                    iP = Px[id]
+                else:
+                    new = False
+                if new:
+                    iP._select()
+                    pts.append(iP)
+
+        Ridge.update = False
+
+        return Ridge(pts)
+
+
+class Ridge:
+    slc, sgt = None, None
+    update = False
+
+    def __init__(self, points: list[Point]):
+        self.pts = points
+
+    def __contains__(self, item):
+        return item in self.pts
+
+    def __iter__(self):
+        return self.pts.__iter__()
+
+    def __len__(self):
+        return len(self.pts)
+
+    def __eq__(self,R):
+        if type(R) is Ridge and len(R)==len(self):
+            return all(i==j for i,j in zip(self,R))
+        return False
+
+    def plot(self, ax=plt, dynamic=False):
+        Cache.update(self)
+        if isinstance(ax, MT):
+            fig, ax = plt.subplots()
+        if dynamic:
+            x = [i.x for i in self.pts]
+            y = [i.y for i in self.pts]
+            if Ridge.slc: Ridge.slc.remove()
+            Ridge.slc, = ax.plot(x, y, c="red", zorder=3)
+        else:
+            x = [i.x for i in self.pts]
+            y = [i.y for i in self.pts]
+            Ridge.sgt, = ax.plot(x, y, c="red", zorder=2)
+
+    @staticmethod
+    def refresh(pts):
+        if not Ridge.update:
+            Ridge.update = True
+            Ridge.sgt.set_color("green")
+            # Ridge.sgt.figure.canvas.draw_idle()
+        icol = {}
+        for P in pts.selected:
+            if P.x in icol:
+                icol[P.x].append(P)
+            else:
+                icol[P.x] = [P]
+
+        X=list(sorted(icol.keys()))
+
+        try:
+            Point.ridge(icol, X, icol[X[0]][len(icol[X[0]])//2]).plot(pts._ax, True)
+        except IndexError:
+            Point.ridge(icol, X, Point(0,2.5)).plot(pts._ax, True)
+
+class Interact:
+    """
+    Owns ONE shared scatter collection for all points (instead of one
+    scatter + one pick_event connection per Point). Selection state still
+    lives on each Point; colors are synced to the shared collection in a
+    single set_facecolors() call rather than per-point set_color().
+    """
+
+    def __init__(self, points: list[Point], ax=plt):
+        if isinstance(ax, MT):
+            ax = ax.gca()
+        self._ax = ax
+        self._points = points
+
+        xs = [p.x for p in self._points]
+        ys = [p.y for p in self._points]
+        colors = [p._col for p in self._points]
+
+        # picker=5 -> hit-test tolerance in points (pixels), rather than
+        # the per-marker contains() test you'd get from picker=True. This
+        # also makes individual points noticeably easier to click than
+        # the old per-point picker=True did.
+        self._scatter = ax.scatter(xs, ys, c=colors, zorder=3, picker=5)
+        ax.figure.canvas.mpl_connect('pick_event', self._on_pick)
+
+        self._rs = RectangleSelector(
+            ax,
+            self._on_select,
+            useblit=True,
+            button=[1],
+            minspanx=5, minspany=5,
+            spancoords='pixels',
+            interactive=False,
+        )
+        ax.figure.canvas.mpl_connect('button_release_event', self._on_click_empty)
+
+    def _sync_colors(self):
+        """Push current per-point colors to the shared collection in one call."""
+        colors = [p._col for p in self._points]
+        self._scatter.set_facecolors(colors)
+
+    def _on_pick(self, event):
+        if event.artist is not self._scatter:
+            return
+        if len(event.ind) == 0:
+            return
+
+        idx = event.ind[0]
+        p = self._points[idx]
+        if p.selected:
+            p._deselect()
+        else:
+            p._select()
+
+        self._sync_colors()
+        Ridge.refresh(self)
+        self._ax.figure.canvas.draw_idle()
+
+
+    def _on_select(self, eclick, erelease):
+        x0, x1 = sorted([eclick.xdata, erelease.xdata])
+        y0, y1 = sorted([eclick.ydata, erelease.ydata])
+
+        span = abs(x1 - x0) + abs(y1 - y0)
+        if span > 1e-10:
+            alt = 'alt' in eclick.modifiers
+            X = eclick.key in ('X', 'X+', 'x', 'x+', 'alt+x', 'alt+X')
+
+            for p in self._points:
+                inside = x0 <= p.x <= x1 and y0 <= p.y <= y1
+                if inside and not X:
+                    p._select()
+                elif not alt and not (inside ^ X):
+                    p._deselect()
+                elif inside and alt and X:
+                    if p.selected:
+                        p._deselect()
+                    else:
+                        p._select()
+
+            self._sync_colors()
+            Ridge.refresh(self)
+
+            self._ax.figure.canvas.draw_idle()
+
+    def _on_click_empty(self, event):
+        if event.inaxes != self._ax:
+            return
+        try:
+            x0, x1, y0, y1 = self._rs.extents
+            span = abs(x1 - x0) + abs(y1 - y0)
+        except Exception:
+            span = 0
+
+        if span < 1e-10 and not any(abs(event.xdata-p.x)<0.1 and abs(event.ydata-p.y)<0.05 for p in self._points):
+
+            alt = 'alt' in event.modifiers
+            X = event.key in ('X', 'X+', 'x', 'x+', 'alt+x', 'alt+X')
+
+            if not (X or alt):
+                for p in self._points:
+                    p._deselect()
+
+                self._sync_colors()
+                Ridge.refresh(self)
+    
+                self._ax.figure.canvas.draw_idle()
+
+    def force(self,R):
+        for p in self._points:
+            if p in R:
+                p._select()
+            else:
+                p._deselect()
+
+        self._sync_colors()
+        R.refresh(self)
+        self._ax.figure.canvas.draw_idle()
+
+    @property
+    def selected(self) -> list[Point]:
+        return [p for p in self._points if p.selected]
+
+'''from functools import total_ordering
+import matplotlib.pyplot as plt
+import numpy as np
+from matplotlib.widgets import RectangleSelector
+from types import ModuleType as MT
+
+def search(arr,n):
+    arr = np.asarray(arr)
+    idx = np.searchsorted(arr, n)
+    if idx == 0:
+        return 0
+    if idx == len(arr):
+        return len(arr) - 1
+    if abs(arr[idx] - n) < abs(arr[idx - 1] - n):
+        return idx
+    return idx - 1
+
+
+
+@total_ordering
+class Point:
+    def __init__(self, x, y):
+        self.__x = x
+        self.__y = y
+        self._deselect()
+
+    @property
+    def x(self):
+        return self.__x
+
+    @property
+    def y(self):
+        return self.__y
+
+    def __call__(self):
+        return self.x, self.y
+
+    def __repr__(self):
+        return f"({self.x}, {self.y})"
+
+    def slope(self,P):
+        if isinstance(P, Point):
+            try:
+                return (P.y - self.y) / (P.x - self.x)
+            except ZeroDivisionError:
+                return float('inf')
+        else:
+            raise TypeError(f"{type(P)} object {P} is incompatible to point {self}")
+
+    def __gt__(self, P):
+        if isinstance(P, Point):
+            return self.x > P.x
+        else:
+            raise TypeError(f"{type(P)} object {P} is incompatible to point {self}")
+
+    def __eq__(self, P):
+        if isinstance(P, Point):
+            return self.x == P.x and self.y == P.y
+        else:
+            raise TypeError(f"{type(P)} object {P} is incompatible to point {self}")
+
+    def _select(self):
+        self.__selected = True
+        self._col="red"
+
+    def _deselect(self):
+        self.__selected = False
+        self._col="green"
+
+    @property
+    def selected(self):
+        return self.__selected
+
+    def __click(self,event):
+        if event.artist not in (self.__plot):
+            return
+
+        if self.selected: self._deselect()
+        else: self._select()
+
+        self.__plot.set_color(self._col)
+
+        event.artist.figure.canvas.draw_idle()
+
+    def _refresh(self):
+        self.__plot.set_color(self._col)
+
+    def plot(self,ax=plt):
+        if isinstance(ax, MT):
+            ax = ax.gca()
+
+        self.__plot = ax.scatter(self.x,self.y,c=self._col,zorder=3,picker=True)
+
+        ax.figure.canvas.mpl_connect('pick_event', self.__click)
+
+    @staticmethod
+    def ridge(icol,xs,iP):
+        pts=[]
+        for x in xs:
+            if len(icol[x])>0:
+                Px=icol[x]
+                y = [i.y for i in Px]
+                id = search(y, iP.y)
+                if y[id]<iP.y and id<len(icol[x])-1:
+                    if y[id+1]-iP.y<2*(iP.y-y[id]): id+=1
+                Px[id]._select()
+                iP=Px[id]
+                pts.append(iP)
+
+        return Ridge(pts)
+    
+    @staticmethod
+    def iridge(icol, xs, iP,tol,bias):
+        pts = []
+        for x in xs:
+            if len(icol[x]) > 0:
+                Px = icol[x]
+                y = [i.y for i in Px]
+                id = search(y, iP.y)
+                ud=id
+                if y[id] < iP.y and id < len(icol[x]) - 1:
+                    if y[id + 1] - iP.y < bias * (iP.y - y[id]): ud += 1
+                new=True
+                if -tol<=iP.slope(Px[ud])<=tol: iP = Px[ud]
+                elif -tol<=iP.slope(Px[id])<=tol: iP = Px[id]
+                else: new=False
+                if new:
+                    iP._select()
+                    pts.append(iP)
+
+        Ridge.update=False
+
+        return Ridge(pts)
+
+
+
+class Ridge:
+
+    slc,sgt=None,None
+    update=False
+
+    def __init__(self, points: list[Point]):
+        self.pts = points
+
+    def __iter__(self):
+        for i in self.pts: yield i
+
+    def plot(self,ax=plt,dynamic=False):
+        if isinstance(ax, MT):
+            fig = plt.Figure()
+            ax = fig.add_subplot(111)
+        if dynamic:
+            x = [i.x for i in self.pts]
+            y = [i.y for i in self.pts]
+            if Ridge.slc: Ridge.slc.remove()
+            Ridge.slc,=ax.plot(x, y, c="red", zorder=3)
+        else:
+            x = [i.x for i in self.pts]
+            y = [i.y for i in self.pts]
+            Ridge.sgt,=ax.plot(x, y, c="red", zorder=2)
+
+    @staticmethod
+    def refresh(pts):
+        if not Ridge.update:
+            Ridge.update=True
+            Ridge.sgt.set_color("green")
+            #Ridge.sgt.figure.canvas.draw_idle()
+        icol = {}
+        for P in pts.selected:
+            if P.x in icol:
+                icol[P.x].append(P)
+            else:
+                icol[P.x] = [P]
+
+        Point.ridge(icol, list(sorted(icol.keys())), Point(0, 2)).plot(pts._ax,True)
+
+
+class Interact:
+
+    def __init__(self, points: list[Point], ax=plt):
+        if isinstance(ax, MT):
+            ax = ax.gca()
+        self._ax = ax
+        self._points = points
+
+        for p in self._points:
+            p.plot(ax)
+
+        self._rs = RectangleSelector(
+            ax,
+            self._on_select,
+            useblit=True,
+            button=[1],
+            minspanx=5, minspany=5,
+            spancoords='pixels',
+            interactive=False,
+        )
+        ax.figure.canvas.mpl_connect('button_release_event', self._on_click_empty)
+
+    def _on_select(self, eclick, erelease):
+        x0, x1 = sorted([eclick.xdata, erelease.xdata])
+        y0, y1 = sorted([eclick.ydata, erelease.ydata])
+
+        alt = eclick.key in ('alt', 'alt+')
+
+        for p in self._points:
+            inside = x0 <= p.x <= x1 and y0 <= p.y <= y1
+            if inside:
+                p._select()
+            elif not alt:
+                p._deselect()
+            p._refresh()
+        Ridge.refresh(self)
+
+        self._ax.figure.canvas.draw_idle()
+
+    def _on_click_empty(self, event):
+        if event.inaxes != self._ax:
+            return
+        try:
+            x0, x1, y0, y1 = self._rs.extents
+            span = abs(x1 - x0) + abs(y1 - y0)
+        except Exception:
+            span = 0
+
+        if span < 1e-10:
+            for p in self._points:
+                p._deselect()
+                p._refresh()
+            Ridge.refresh(self)
+
+            self._ax.figure.canvas.draw_idle()
+
+    @property
+    def selected(self) -> list[Point]:
+        return [p for p in self._points if p.selected]
+'''

--- a/msnoise_tomo/cache.py
+++ b/msnoise_tomo/cache.py
@@ -1,0 +1,40 @@
+class Cache:
+
+    _cache=[None]
+    _i=0
+
+    @staticmethod
+    def update(ele):
+        if ele != Cache.current:
+            if not Cache._cache[Cache._i]:
+                Cache._cache[Cache._i]=ele
+            else:
+                Cache._i+=1
+                if Cache._i==len(Cache._cache): Cache._cache.append(None)
+                Cache._cache[Cache._i]=ele
+            Cache._cache=Cache._cache[:Cache._i+1]
+
+    @staticmethod
+    def undo():
+        if Cache._i>0:
+            Cache._i-=1
+            return Cache._cache[Cache._i]
+        return None
+
+    @staticmethod
+    def redo():
+        if Cache._i<len(Cache._cache)-1:
+            Cache._i+=1
+            return Cache._cache[Cache._i]
+        return None
+
+    @staticmethod
+    def refresh():
+        Cache._cache=[None]
+        Cache._i=0
+
+
+    @classmethod
+    @property
+    def current(cls):
+        return cls._cache[Cache._i]

--- a/msnoise_tomo/ftan.py
+++ b/msnoise_tomo/ftan.py
@@ -80,7 +80,13 @@ def main(pair, bmin, bmax, show):
                 # fn = os.path.join("TOMO_SAC", "%s_%s_REAL.SAC"%(netsta2.replace('.','_'), netsta1.replace('.','_')))
                 # SACfilelist.append(fn)
                 fn = os.path.join("TOMO_SAC", "%s_%s_MEAN.sac"%(netsta1.replace('.','_'), netsta2.replace('.','_')))
-                SACfilelist.append(fn)
+                if not os.path.exists(os.path.join("DISP CURVE PLOTS",
+                                                   "%s - %s.png" % (netsta1, netsta2))):  #
+                    if os.path.isfile(fn):
+                        SACfilelist.append(fn)
+                        savefiles.append("DISP CURVE PLOTS")
+                    else:
+                        print("no file named", fn)
                 break
             pair = None
         

--- a/msnoise_tomo/ftan.py
+++ b/msnoise_tomo/ftan.py
@@ -51,6 +51,7 @@ def main(pair, bmin, bmax, show):
 
     while is_next_job(db, jobtype='TOMO_FTAN') or pair:
         SACfilelist = []
+        savefiles=[]
         if not pair:
             jobs = get_next_job(db, jobtype='TOMO_FTAN')
 
@@ -65,10 +66,12 @@ def main(pair, bmin, bmax, show):
                     for comp in comps:
                         fn = os.path.join("TOMO_SAC", "%02i"%filter.ref, comp, "%s_%s_MEAN.sac"%(netsta1.replace('.','_'), netsta2.replace('.','_')))
                         print(fn)
-                        if os.path.isfile(fn):
-                            SACfilelist.append(fn)
-                        else:
-                            print("no file named", fn)
+                        if not os.path.exists(os.path.join("DISP CURVE PLOTS","%02i"%filter.ref, comp, "%s - %s.png"%(netsta1, netsta2))): #
+                            if os.path.isfile(fn):
+                                SACfilelist.append(fn)
+                                savefiles.append(os.path.join("DISP CURVE PLOTS","%02i"%filter.ref, comp))
+                            else:
+                                print("no file named", fn)
         else:
             for pi in pair:
                 netsta1, netsta2 = pi.split('_')
@@ -133,10 +136,13 @@ def main(pair, bmin, bmax, show):
             ymax = max(U)
 
             # filter only the picks that are within the y-limits
-            iu = np.where( (disper>=ymin) & (disper<=ymax) )
+            condition = (disper >= ymin) & (disper <= ymax)
+            iu = np.where(np.atleast_1d(condition))
             # print(iu[0])
             if len(iu[0]) != 0: # need to check if iu is empty.
+                per = np.atleast_1d(per)
                 per    = per[iu]
+                disper = np.atleast_1d(disper)
                 disper = disper[iu]  
                 
                 # Make sure you have the correct vectors; convert as needed
@@ -176,7 +182,7 @@ def main(pair, bmin, bmax, show):
             # maxp[i] = np.max(GVdisp[i]["PERIOD"])
 
             if PLOTDIAGR:
-                plot_FTAN_result(filename, basename, per, disper, diagramtype)
+                plot_FTAN_result(filename, basename, per, disper, diagramtype, savefiles[i])
 
 
         # Done with loop over the SAC files. Things below here
@@ -236,7 +242,7 @@ def write_tomo_disp_file(filename, basename, dcii, PER):
         os.makedirs(os.path.split(fn)[0])
     df.to_csv(fn, header=[basename,], float_format='%.4f')
 #==============================================================================
-def plot_FTAN_result(filename, basename, per, disper, diagramtype):
+def plot_FTAN_result(filename, basename, per, disper, diagramtype,save):
     # This function will plot the FTAN matrix and overlay the dispersion curve
 
     # get FTAN matrix
@@ -278,7 +284,12 @@ def plot_FTAN_result(filename, basename, per, disper, diagramtype):
 
     NET1, STA1, NET2, STA2, crap = os.path.split(filename)[1].split('_')
 
-    plt.title("FTAN\n%s.%s - %s.%s"%(NET1, STA1, NET2, STA2))
+    title="%s.%s - %s.%s"%(NET1, STA1, NET2, STA2)
+
+    plt.title("FTAN\n"+title)
+
+    os.makedirs(save, exist_ok=True) #
+    plt.savefig(os.path.join(save,f"{title}.png")) #
     plt.show()
 #==============================================================================
 def plot_raw_dispersion_curves(GVdisp):
@@ -327,7 +338,7 @@ def plot_interp_dispersion_curves(PER, Disp):
 def write_interp_disp_curve(PER, Disp, GVdisp):
     # Write a file for each period requrest by the user.
     # Each row in the file is a dispersion measurement between two stations
-    # PER = all of the periods requested by the user in tomoconfig
+    # PER = all the periods requested by the user in tomoconfig
     # Disp = [np,nd] group velocities at each period (np) for each station pair (nd)
 
     datapathout = "GROUPVEL_FILES/"

--- a/msnoise_tomo/ftan.py
+++ b/msnoise_tomo/ftan.py
@@ -248,8 +248,10 @@ def write_tomo_disp_file(filename, basename, dcii, PER):
         os.makedirs(os.path.split(fn)[0])
     df.to_csv(fn, header=[basename,], float_format='%.4f')
 #==============================================================================
-def plot_FTAN_result(filename, basename, per, disper, diagramtype,save):
+def plot_FTAN_result(filename, basename, per, disper, diagramtype,save,show=True):
     # This function will plot the FTAN matrix and overlay the dispersion curve
+
+    print(filename,basename)
 
     # get FTAN matrix
     amp = np.loadtxt('%s_amp.txt'%basename).T
@@ -296,7 +298,7 @@ def plot_FTAN_result(filename, basename, per, disper, diagramtype,save):
 
     os.makedirs(save, exist_ok=True) #
     plt.savefig(os.path.join(save,f"{title}.png")) #
-    plt.show()
+    #plt.show()
 #==============================================================================
 def plot_raw_dispersion_curves(GVdisp):
     # This function will plot the raw dispersion curves that are come from write_disp.txt.

--- a/msnoise_tomo/ftan_call.py
+++ b/msnoise_tomo/ftan_call.py
@@ -105,24 +105,54 @@ def pickgroupdispcurv(filename, fmin, fmax, vgmin, vgmax, bmin, bmax,
     time.sleep(0.1)
     # TODO still need to figure out how to use the tginit input in the C++ code. vinit doesn't seem to have an impact!
 
-    '''
-    '''
-    from .idisp_pick import pick
-    pick(amp.T,P,V)
-    '''
-    '''
-
-   	# Process the automatically picked dispersion curve from jonubhab's code. Ha! Ha! Ha!
+    # Process the automatically picked dispersion curve from C++ code.
     D = np.loadtxt('write_disp.txt')
-    if D.ndim == 2: # make sure that there is more than one pick
-        isort  = np.argsort(D[:,0]) # sort based on the first column (period)
-        D      = D[isort]
-        per    = D[:,0]
-        disper = D[:,1]
+    if D.ndim == 2:  # make sure that there is more than one pick
+        isort = np.argsort(D[:, 0])  # sort based on the first column (period)
+        D = D[isort]
+        per = D[:, 0]
+        disper = D[:, 1]
     else:
         print("Only one dispersion pick...check data!!!")
         per = D[0]
         disper = D[1]
+
+
+
+    '''
+    '''
+    per=np.atleast_1d(per)
+    disper=np.atleast_1d(disper)
+    comp=os.path.basename(os.path.dirname(filename))
+
+    from .Caller import main
+    from .idisp_pick import idisp
+    iwin=idisp(amp,P,V,per,disper)
+
+    data={"idisp":iwin,
+          "filename":filename,
+          "dist":dist,
+          "comp":comp}
+    main(data)
+
+    if iwin.picked:
+        # Process the automatically picked dispersion curve from jonubhab's code. Ha! Ha! Ha!
+        D = np.loadtxt('write_disp.txt')
+        if D.ndim == 2:  # make sure that there is more than one pick
+            isort = np.argsort(D[:, 0])  # sort based on the first column (period)
+            D = D[isort]
+            per = D[:, 0]
+            disper = D[:, 1]
+        else:
+            print("Only one dispersion pick...check data!!!")
+            per = D[0]
+            disper = D[1]
+
+
+    '''
+    '''
+
+
 
 
 

--- a/msnoise_tomo/ftan_call.py
+++ b/msnoise_tomo/ftan_call.py
@@ -66,6 +66,7 @@ def pickgroupdispcurv(filename, fmin, fmax, vgmin, vgmax, bmin, bmax,
             print("Seed period: %f"%pinit)	
 
 
+
     # # Set the starting points depending on which plot type
     # if diagramtype == 'PV':
     #     finit = "%.5f"% (1./pinit)
@@ -104,7 +105,14 @@ def pickgroupdispcurv(filename, fmin, fmax, vgmin, vgmax, bmin, bmax,
     time.sleep(0.1)
     # TODO still need to figure out how to use the tginit input in the C++ code. vinit doesn't seem to have an impact!
 
-   	# Process the automatically picked dispersion curve from the C++ code.
+    '''
+    '''
+    from .idisp_pick import pick
+    pick(amp.T,P,V)
+    '''
+    '''
+
+   	# Process the automatically picked dispersion curve from jonubhab's code. Ha! Ha! Ha!
     D = np.loadtxt('write_disp.txt')
     if D.ndim == 2: # make sure that there is more than one pick
         isort  = np.argsort(D[:,0]) # sort based on the first column (period)
@@ -115,6 +123,9 @@ def pickgroupdispcurv(filename, fmin, fmax, vgmin, vgmax, bmin, bmax,
         print("Only one dispersion pick...check data!!!")
         per = D[0]
         disper = D[1]
+
+
+
 
     # print(per)
     # print(disper)

--- a/msnoise_tomo/idisp_pick.py
+++ b/msnoise_tomo/idisp_pick.py
@@ -1,0 +1,16 @@
+import numpy as np
+from .Map import *
+
+def pick(amp,P,V):
+    M = Map(amp, P, V)
+    M.setTol(0.2,1)
+    pts=M.plot(plt)
+
+    icol={}
+    for P in pts.selected:
+        if P.x in icol: icol[P.x].append(P)
+        else: icol[P.x]=[P]
+
+    pts=Point.ridge(icol,list(sorted(icol.keys())),Point(0,2))
+    D=np.array([[*i(),M[i]] for i in pts])
+    np.savetxt('write_disp.txt',D,header='Period(s) Velocity(km/s) Energy')

--- a/msnoise_tomo/idisp_pick.py
+++ b/msnoise_tomo/idisp_pick.py
@@ -1,16 +1,54 @@
 import numpy as np
 from .Map import *
+from matplotlib.widgets import Button
+import os
+from .cache import Cache
 
-def pick(amp,P,V):
-    M = Map(amp, P, V)
-    M.setTol(0.2,1)
-    pts=M.plot(plt)
+class idisp:
 
-    icol={}
-    for P in pts.selected:
-        if P.x in icol: icol[P.x].append(P)
-        else: icol[P.x]=[P]
+    def __init__(self,amp,P,V,per,disper):
+        self.amp=amp
+        self.P=P
+        self.V=V
+        self.per=per
+        self.disper=disper
+        self.picked=False
+        Cache.refresh()
+        Cache.update(Ridge([Point(x,y) for x, y in zip(per,disper)]))
 
-    pts=Point.ridge(icol,list(sorted(icol.keys())),Point(0,2))
-    D=np.array([[*i(),M[i]] for i in pts])
-    np.savetxt('write_disp.txt',D,header='Period(s) Velocity(km/s) Energy')
+    def main(self,filename,dist,comp):
+        Per, Vitg = np.meshgrid(self.P, self.V)
+        fig=plt.Figure()
+        ax=fig.add_subplot(111)
+        heatmap = ax.contourf(Per, Vitg, self.amp, 35, cmap=inferno)
+        fig.colorbar(heatmap, label="Signal Strength")
+        ax.plot(self.per, self.disper, '-ok', lw=1.5)
+        ax.set_xlim(self.P[0], self.P[-1])
+        ax.set_ylim(self.V[0], self.V[-1])
+        ax.set_xlabel("Period (s)")
+        ax.set_ylabel("Velocity (km/s)")
+        NET1, STA1, NET2, STA2, crap = os.path.split(filename)[1].split('_')
+        self.name = "%s.%s - %s.%s (%.2f km) %s" % (NET1, STA1, NET2, STA2, dist,comp)
+        ax.set_title(self.name)
+        return fig
+
+    def pick(self,Xtol,Ytol,mtol,AMPmin,bias,name="2D Heatmap",per=[],disper=[]):
+        M = Map(self.amp.T, self.P, self.V, name)
+        M.setTol(Xtol,Ytol,mtol,AMPmin,bias)
+        M.default(per,disper)
+        fig,pts = M.plot(plt)
+        self.M = M  # keep around so callers can look up amplitude via idisp.M[point]
+
+        return fig,pts
+'''
+        icol = {}
+        for P in pts.selected:
+            if P.x in icol:
+                icol[P.x].append(P)
+            else:
+                icol[P.x] = [P]
+
+        pts = Point.ridge(icol, list(sorted(icol.keys())), Point(0, 2))
+        D = np.array([[*i(), M[i]] for i in pts])
+        np.savetxt('write_disp.txt', D, header='Period(s) Velocity(km/s) Energy')
+'''

--- a/msnoise_tomo/iftan.py
+++ b/msnoise_tomo/iftan.py
@@ -196,6 +196,11 @@ def main():
         p.set_xlim(xmin, xmax)
         p.set_ylim(ymin, ymax)
         p.set_title("%s.%s - %s.%s (%.2f km)" % (NET1, STA1, NET2, STA2, dist))
+
+        title = "%s.%s - %s.%s" % (NET1, STA1, NET2, STA2)
+        os.makedirs("DISP CURVE PLOTS", exist_ok=True)
+        f.savefig(f"DISP CURVE PLOTS/{title}.png")
+        
         canvas.draw()
 
     def previous_file(e=None):

--- a/msnoise_tomo/plugin_definition.py
+++ b/msnoise_tomo/plugin_definition.py
@@ -48,7 +48,7 @@ def ftan_example():
     from .examplepickdispcurve import main
     main()
 
-@click.option('-p', '--pair', default=None,  help='FTAN a specific pair',
+@click.option('-p', '--pair', default=None,  help='FTAN a specific pair\tFormat: NET.STA1_NET.STA2',
               multiple=True)
 @click.option('-b', '--bmin', default=None,  help='force bmin',)
 @click.option('-B', '--bmax', default=None,  help='force bmax',)
@@ -57,6 +57,20 @@ def ftan_example():
 def ftan(pair, bmin, bmax, show):
     from .ftan import main
     main(pair, bmin, bmax, show)
+
+@click.option('-a','--all',is_flag=True, default=False,help='Reset the entire FTAN process and start from scratch.')
+@click.command(name="reset_ftan")
+def reset_ftan(all):
+    if all:
+        confirm_text = click.prompt(
+            "This will reset ALL FTAN jobs and progress. Type 'DELETE PROGRESS' to continue"
+        )
+        if confirm_text.strip() != "DELETE PROGRESS":
+            click.echo("Aborted.")
+            return
+    from .reset_ftan import main
+    main(all)
+
 
 @click.command()
 def iftan():
@@ -111,6 +125,7 @@ tomo.add_command(ftan_example)
 tomo.add_command(prepare_ccf)
 tomo.add_command(prepare_tomo)
 tomo.add_command(ftan)
+tomo.add_command(reset_ftan)
 tomo.add_command(iftan)
 tomo.add_command(install)
 tomo.add_command(answt)

--- a/msnoise_tomo/reset_ftan.py
+++ b/msnoise_tomo/reset_ftan.py
@@ -1,0 +1,32 @@
+import os
+from msnoise.api import *
+from sqlalchemy import text
+
+def main(all):
+    db = connect()
+    result = db.execute(text("UPDATE jobs SET flag='T' WHERE jobtype='TOMO_FTAN'"))
+    db.commit()
+    deleted=0
+    if all:
+        params = get_params(db)
+        comps = params.components_to_compute
+        filters = get_filters(db)
+        while is_next_job(db, jobtype='TOMO_FTAN'):
+            jobs = get_next_job(db, jobtype='TOMO_FTAN')
+
+            for job in jobs:
+                netsta1, netsta2 = job.pair.split(':')
+                for filter in filters:
+                    for comp in comps:
+                        fn = os.path.join("DISP CURVE PLOTS", "%02i" % filter.ref, comp,
+                                          "%s - %s.png" % (netsta1, netsta2))
+                        if os.path.exists(fn):
+                            os.remove(fn)
+                            deleted+=1
+        result = db.execute(text("UPDATE jobs SET flag='T' WHERE jobtype='TOMO_FTAN'"))
+        db.commit()
+    print(f"{result.rowcount} jobs reset to T")
+    print(f"{deleted} jobs deleted.")
+
+if __name__ == "__main__":
+    main()

--- a/msnoise_tomo/show.py
+++ b/msnoise_tomo/show.py
@@ -1,0 +1,49 @@
+def plot_FTAN_result(filename, basename, per, disper, diagramtype,save,show=True):
+    # This function will plot the FTAN matrix and overlay the dispersion curve
+
+    # get FTAN matrix
+    amp = np.loadtxt('%s_amp.txt'%basename).T
+
+    # Process the dispersion curve
+    U = np.loadtxt('%s_TV.txt'%basename)
+    P = np.loadtxt('%s_FP.txt'%basename)
+    # get axes limits
+    xmin = min(P)
+    xmax = max(P)
+    ymin = min(U)
+    ymax = max(U)
+
+    # setup matrix for contour plot
+    Per, Vitg = np.meshgrid(P,U)
+    plt.figure()
+    plt.contourf(Per, Vitg, amp, 35, cmap=viridis)
+    plt.colorbar()
+    # plt.contour(Per, Vitg, amp, 35, colors='k')
+
+    plt.plot(per, disper,'-ok',lw=1.5)
+    plt.xlim(xmin, xmax)
+    plt.ylim(ymin, ymax)
+
+    # Set axes labels depending on diagramtype
+    if diagramtype == 'PV':
+        plt.xlabel("Period (s)")
+        plt.ylabel("Velocity (km/s)")
+    elif diagramtype == 'FV':
+        plt.xlabel("Frequency (Hz)")
+        plt.ylabel("Velocity (km/s)")
+    elif diagramtype == 'FT':
+        plt.xlabel("Frequency (Hz)")
+        plt.ylabel("Time (s)")
+    elif diagramtype == 'PT':
+        plt.xlabel("Period (s)")
+        plt.ylabel("Time (s)")
+
+    NET1, STA1, NET2, STA2, crap = os.path.split(filename)[1].split('_')
+
+    title="%s.%s - %s.%s"%(NET1, STA1, NET2, STA2)
+
+    plt.title("FTAN\n"+title)
+
+    os.makedirs(save, exist_ok=True) #
+    plt.savefig(os.path.join(save,f"{title}.png")) #
+    #plt.show()


### PR DESCRIPTION
# Interactive Dispersion Curve Picking
 
This adds an interactive picking step on top of MSNoise Tomo's FTAN stage. It doesn't replace anything in the existing pipeline — it sits between the C++ FTAN computation and the file it normally writes (`write_disp.txt`), letting you see and correct what gets picked before it's handed off to `TOMO_DISP`.
 
## The problem this solves
 
If you've run the stock FTAN step on a real dataset, you've probably hit some combination of these:
 
- The dispersion curve `vg_fta.so` hands back often isn't trustworthy. It jumps between unrelated peaks in the FTAN diagram and the resulting curve gets discontinuous in several places, with no way to see *why* it picked what it picked.
- There was no real way to intervene — IFTAN exists, but driving it to fix a single bad pick is more confusing than it should be.
- FTAN flags every job as done as soon as a batch starts. If a run gets interrupted or crashes partway through, the jobs already *look* finished to MSNoise, so you can't just resume — you have to manually sort out which pairs actually have a usable result.
- After running FTAN repeatedly in the same session, the program eventually stops being able to load new contour plots at all.
## What this adds
 
- A peak-detection pass over the full group-velocity-vs-period (or frequency) SNR field for each pair, which finds every local maximum and stitches together the most continuous dispersion curve it can from them.
- That algorithm-picked curve overrides whatever the raw FTAN binary would have used on its own, and instead of trusting it blindly, it's shown to you on a plot so you can accept or correct it.
- Every candidate peak is plotted as a clickable point. You build your own curve by selecting points with the mouse; your selection is drawn in red, and the algorithm's own continuous guess is drawn in green underneath it for reference.
- The picking parameters (described below) are exposed in a panel so you can tune them per pair, and your last-used values are cached to disk so you don't have to retype them for every single pair in a batch.
- Undo/redo/clean controls so a bad rectangle-select or a stray misclick doesn't cost you the whole pair.
- A `reset_ftan` command that lets you safely resume an interrupted batch, or — if you really need to — wipe everything and start clean.
- A "Reboot" shortcut for the specific failure mode where FTAN stops being able to render new plots after running for a while: it terminates, resets the affected job(s), and restarts `msnoise p tomo ftan` for you.
The final curve, once you save it, is rendered to a `.png` for your records and `write_disp.txt` is overwritten with your picks — from there, the existing MSNoise code relocates it into `TOMO_DISP/` exactly as before.

## Files changed and added

### Modified

| File | What changed |
|---|---|
| `plugin_definition.py` | Added the `reset_ftan` command to the `tomo` CLI group, including the `--all` flag and its `DELETE PROGRESS` confirmation gate. |
| `ftan.py` | Before queuing a SAC file for processing, now checks whether its output plot already exists under `DISP CURVE PLOTS/`. If it does, that pair is skipped — this is what lets a resumed run skip pairs you've already picked instead of redoing the whole batch. |
| `ftan_call.py` | After the FTAN binary's second (refined) pass, builds the picker's data object from its output and hands control to the picker window. If you used the picker, reloads `write_disp.txt` afterward so your edited picks — rather than the binary's raw output — are what get carried forward. |

### Added

| File | What it does |
|---|---|
| `Caller.py` | Launches the picker window, blocks until you close it, then pulls out whatever ridge you ended up with and writes it to `write_disp.txt`. |
| `Interface.py` | The picker GUI itself — the plot panel, the parameter panel with the five tunable values, dark mode, and the Pick/Undo/Redo/Clean/Save/Reboot buttons. |
| `Map.py` | The peak-detection scan — for each period/frequency column, finds local maxima in the SNR field using the `Xtol`/`Ytol`/`AMPmin` tolerances. |
| `Point.py` | Represents each candidate peak (its position and selected/deselected state), the ridge-stitching logic (`mtol`/`bias`), and `Interact`, which owns the shared scatter plot and handles all the click/drag/alt/x mouse interactions. |
| `cache.py` | The small history stack behind Undo, Redo, and Clean. |
| `idisp_pick.py` | Bridges the raw FTAN output (amplitude matrix, axes, the binary's own picked curve) to the picker GUI — builds both the initial review plot and the interactive picking plot. |
| `reset_ftan.py` | Implements both `reset_ftan` modes: the flag-only reset, and the destructive `--all` wipe that also deletes saved plots. |
 
## How the picking algorithm works
 
For each period (or frequency) column in the FTAN amplitude diagram, the algorithm looks for local maxima in velocity, filtering out anything below a noise floor and merging maxima that are too close together to be meaningfully distinct. It then walks across columns, trying to connect one maximum per column into a single continuous ridge, rejecting connections that would require an implausibly large jump in velocity from one column to the next.
 
The five parameters below control exactly how forgiving each of those steps is. Defaults are a reasonable starting point, but the right values genuinely depend on your data — frequency content, noise level, and station spacing all affect how clean the FTAN diagram looks. Expect to nudge them a little on your first few pairs. Once you land on values that work for your dataset, you won't have to re-enter them: the panel remembers your last-used values and reloads them automatically the next time the window opens.
 
| Parameter | Label in the GUI | What it controls |
|---|---|---|
| `Xtol` | X Peak Isolation | Minimum separation, along the period/frequency axis, for two candidate peaks to count as distinct. Anything closer together is merged into one (the stronger peak wins). |
| `Ytol` | Y Peak Isolation | The same idea, but along the velocity axis. |
| `AMPmin` | Minimum SNR | Noise floor. Points in the FTAN diagram below this amplitude are never considered candidate peaks at all. |
| `mtol` | Slope Tolerance | The steepest allowed jump in velocity between two consecutive picks. If connecting the next candidate would exceed this, the ridge breaks there instead of jumping to an unrelated peak. |
| `bias` | Positive Slope Bias | When there's a tie between two nearby candidates for the next point on the ridge, this biases the choice toward the one with higher velocity — i.e. toward a positive slope, which is the more common shape for a real dispersion curve. |
 
Both `Xtol` and `Ytol` are in the same units as whatever's on the plot's axes (so typically seconds and km/s, but this follows your diagram type).
 
## Selecting points with the mouse
 
Once you click **Pick**, every candidate peak appears as a point on the contour plot and you're in selection mode:
 
| Action | Effect |
|---|---|
| Click a single point | Toggle that point's selection on/off |
| Click-and-drag a box | Select everything inside the box, deselect everything outside it |
| **Alt** + drag a box | Add the points inside the box to your current selection, without touching anything else |
| **X** (hold) + drag a box | Deselect only the points inside the box |
| **Alt** + **X** + drag a box | Toggle (flip) the selection of just the points inside the box |
| Click an empty part of the canvas | Deselect everything |
 
Your live selection is drawn in red; the algorithm's own reference curve stays green underneath it so you can always compare the two.
 
## The Toolbar
 
**Pick** — Runs the peak-detection algorithm with whatever parameter values are currently in the panel, and switches you into selection mode. Use it when:
- You don't like the pre-selected (green) curve and want to build your own from the candidate points, or
- You've just changed one of the five parameters and want to see how the set of candidate maxima changes before you commit to a selection.

**Undo** — Steps back to your previous selection state. Use it to recover from a misclick, or to back out of a selection that turned out worse than the one you had before.
 
**Redo** — Steps forward again. Paired with Undo, this lets you flip back and forth between two candidate ridges to compare them before deciding which one to keep.
 
**Clean** — Deselects any points you've picked that aren't actually part of the connected ridge — stray clicks, accidental extra selections, that sort of thing. Under the hood it doesn't go scanning for which points are "stray"; it just reloads the cached state of the current ridge, since that's already sitting in memory.
 
**Save** — Commits your current selection (or the original algorithm curve, if you never clicked Pick at all) as the final dispersion curve for this pair, writes it out, and closes the window so the pipeline can move on. If the default curve already looked fine to you, you can skip picking entirely and just hit Save.
 
**Reboot** — For when FTAN has stopped being able to load new contour plots after running for a while in the same session: this terminates the current process, resets the affected job(s), and restarts `msnoise p tomo ftan` automatically so you don't have to do it by hand.
 
### The matplotlib navigation toolbar
 
**Zoom** — Enlarges a region of the plot. Useful when a stretch of the FTAN diagram has a dense cluster of candidate points and you need more room to click the right one.
 
**Pan** — Shifts the view without changing the zoom level. Most of the time this is just for moving around a zoomed-in region, but it has one more niche use: points sitting right at the edge of the plot sometimes don't register clicks or fall inside a drag box properly. Panning the view so that point is no longer at the very edge usually fixes it.
 
**Home** — Resets the view back to the original, full extent.
 
### Closing the window
 
Closing the window with the operating system's own **X / close button** is deliberately different from Save: instead of writing anything out, it safely terminates the process and resets the job for that pair, so MSNoise sees it as not-yet-done rather than wrongly marked complete. This means `msnoise p tomo ftan` will pick that pair back up cleanly the next time you run it — but it also means closing this way does **not** save whatever you'd selected. Use Save when you want to keep a pick; use the close button when you want to bail out of the current pair without keeping anything.
 
## Dark mode
 
The picker checks your OS's light/dark setting on startup and matches it automatically, falling back to light mode if it can't tell. You can flip it manually at any point with the dark-mode shortcut below — this recolors the plot, the panel, and the toolbar icons together.
 
## Keyboard shortcuts
 
| Key(s) | Action |
|---|---|
| Enter, Ctrl+P | Pick |
| Ctrl+Z | Undo |
| Ctrl+Y | Redo |
| Ctrl+V, Alt+V | Clean |
| Ctrl+S | Save |
| Ctrl+R | Reboot |
| Ctrl+D | Toggle dark mode |
| o, Shift+Z | Toolbar: Zoom *(plot must have focus)* |
| p, Shift+M | Toolbar: Pan *(plot must have focus)* |
| h, Shift+H, Home | Toolbar: Home/reset view *(plot must have focus)* |
| ← | Back to previous view *(plot must have focus)* |
| → | Forward to next view *(plot must have focus)* |
| \\, \|, r | Return focus to the plot canvas |
 
The plot-navigation shortcuts only fire while the plot itself has focus — click on the plot once if they don't seem to respond.
 
## Resuming or resetting a run
 
```
msnoise p tomo reset_ftan
```
Resets the job flags for the FTAN stage without deleting anything on disk. Combined with the fact that a pair already has a saved plot is treated as "done" and skipped automatically, this is the safe way to resume after an interruption — finished pairs stay finished, unfinished ones get picked back up.
 
```
msnoise p tomo reset_ftan --all
```
A full wipe: deletes every saved plot and resets every job. Since this throws away all picking progress and can't be undone, it asks you to type `DELETE PROGRESS` to confirm before doing anything.
 
## Output files
 
| File / folder | Contents |
|---|---|
| `DISP CURVE PLOTS/<filter>/<comp>/<STA1> - <STA2>.png` | The rendered review plot for the pair — also doubles as the marker that tells a future run this pair is already done |
| `DISP CURVE PLOTS/params.pkl` | Your last-used picking parameters |
| `write_disp.txt` | The final (Period, Velocity, Energy) picks for the current pair, picked up from there by the existing MSNoise code and relocated into `TOMO_DISP/` |
 